### PR TITLE
Add ASP.NET Core API with Azure AD JWT auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Ignore build outputs
+bin/
+obj/
+**/bin/
+**/obj/
+# Rider/VS settings
+*.user
+*.csproj.user

--- a/backend/API/API.csproj
+++ b/backend/API/API.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/backend/API/API.http
+++ b/backend/API/API.http
@@ -1,0 +1,6 @@
+@API_HostAddress = http://localhost:5170
+
+GET {{API_HostAddress}}/weatherforecast/
+Accept: application/json
+
+###

--- a/backend/API/Controllers/WeatherForecastController.cs
+++ b/backend/API/Controllers/WeatherForecastController.cs
@@ -1,0 +1,48 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
+
+namespace API.Controllers;
+
+[ApiController]
+[Route("[controller]")]
+[Authorize]
+public class WeatherForecastController : ControllerBase
+{
+    private static readonly string[] Summaries = new[]
+    {
+        "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+    };
+
+    private readonly ILogger<WeatherForecastController> _logger;
+
+    public WeatherForecastController(ILogger<WeatherForecastController> logger)
+    {
+        _logger = logger;
+    }
+
+    [HttpGet(Name = "GetWeatherForecast")]
+    public IEnumerable<WeatherForecast> Get()
+    {
+        return Enumerable.Range(1, 5).Select(index => new WeatherForecast
+        {
+            Date = DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
+            TemperatureC = Random.Shared.Next(-20, 55),
+            Summary = Summaries[Random.Shared.Next(Summaries.Length)]
+        })
+        .ToArray();
+    }
+
+    [HttpGet("admin")]
+    [Authorize(Roles = "Admin")]
+    public string GetForAdmin()
+    {
+        return "Secret admin data";
+    }
+
+    [HttpGet("claims")]
+    [Authorize(Policy = "ReadPolicy")]
+    public string GetForReadClaim()
+    {
+        return "Data requiring read_access claim";
+    }
+}

--- a/backend/API/Program.cs
+++ b/backend/API/Program.cs
@@ -1,0 +1,40 @@
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container.
+
+builder.Services.AddControllers();
+
+builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer(options =>
+    {
+        options.Authority = $"{builder.Configuration["AzureAd:Instance"]}{builder.Configuration["AzureAd:TenantId"]}/v2.0";
+        options.Audience = builder.Configuration["AzureAd:ClientId"];
+    });
+
+builder.Services.AddAuthorization(options =>
+{
+    options.AddPolicy("ReadPolicy", policy =>
+        policy.RequireClaim("read_access", "true"));
+});
+// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseHttpsRedirection();
+app.UseAuthentication();
+
+app.UseAuthorization();
+
+app.MapControllers();
+
+app.Run();

--- a/backend/API/Properties/launchSettings.json
+++ b/backend/API/Properties/launchSettings.json
@@ -1,0 +1,41 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:44277",
+      "sslPort": 44325
+    }
+  },
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "http://localhost:5170",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "https://localhost:7174;http://localhost:5170",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/backend/API/WeatherForecast.cs
+++ b/backend/API/WeatherForecast.cs
@@ -1,0 +1,12 @@
+namespace API;
+
+public class WeatherForecast
+{
+    public DateOnly Date { get; set; }
+
+    public int TemperatureC { get; set; }
+
+    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+
+    public string? Summary { get; set; }
+}

--- a/backend/API/appsettings.Development.json
+++ b/backend/API/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/backend/API/appsettings.json
+++ b/backend/API/appsettings.json
@@ -1,0 +1,14 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "AzureAd": {
+    "Instance": "https://login.microsoftonline.com/",
+    "TenantId": "your-tenant-id",
+    "ClientId": "your-client-id"
+  }
+}


### PR DESCRIPTION
## Summary
- create .NET 8 Web API project under `backend/`
- add Azure AD JWT bearer authentication setup
- apply role and claim-based authorization in controller
- include gitignore for build artifacts

## Testing
- `dotnet restore`
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_686683d697448327ab8dd112998674d1